### PR TITLE
Include extra teaching session in schedule day 3

### DIFF
--- a/_includes/ea/schedule.html
+++ b/_includes/ea/schedule.html
@@ -33,12 +33,13 @@
     <h3>Day 3, September 30</h3>
     <table class="table table-striped">
       <tr> <td>09:00</td>  <td>Welcome and testing online setup</td> </tr>
-      <tr> <td>09:15</td>  <td>Fitting Data in Python</td> </tr>
+      <tr> <td>09:15</td>  <td>Loading and visualizing data in Python</td> </tr>
       <tr> <td>10:45</td>  <td>Coffee Break</td> </tr>
       <tr> <td>11:00</td>  <td>Work in Teams on your Data</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
-      <tr> <td>13:00</td>  <td>Work in Teams Conninued</td> </tr>
+      <tr> <td>13:00</td>  <td>Fitting Data in Python</td> </tr>
       <tr> <td>14:30</td>  <td>Afternoon break</td> </tr>
+      <tr> <td>14:45</td>  <td>Work in Teams Conninued</td> </tr>
       <tr> <td>16:15</td>  <td>Wrap-up</td> </tr>
       <tr> <td>16:30</td>  <td>END</td> </tr>
     </table>


### PR DESCRIPTION
As we discussed in the last debrief, we need an extra (optional) teaching session on day 3 if we want to teach about fitting data.
